### PR TITLE
Add PR template, closes #6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_post.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_post.md
@@ -1,0 +1,13 @@
+This PR adds a new post:
+
+# Content
+
+<!-- Short abstract/description of the post -->
+
+
+# Checklist
+
+ 1. [ ] No external resources (Check `README.md` how to add assets)
+ 2. [ ] References and citations are correct
+ 3. [ ] Commits `squash`ed, so that the post is contained within one commit
+

--- a/.github/PULL_REQUEST_TEMPLATE/new_post.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_post.md
@@ -7,7 +7,8 @@ This PR adds a new post:
 
 # Checklist
 
- 1. [ ] No external resources (Check `README.md` how to add assets)
+ 1. [ ] Every created and owned resource is located as an asset next to the post (Check `README.md` how to add assets). External resources are kept to a minimum
+ 2. [ ] Every external resource is properly cited
  2. [ ] References and citations are correct
  3. [ ] Commits `squash`ed, so that the post is contained within one commit
 


### PR DESCRIPTION
This PR adds a template for new posts to close #6. 

It places the template in a directory to allow for multiple templates (as described in https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository )